### PR TITLE
Deploy website to Google App Engine

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -67,6 +67,10 @@ module.exports = (grunt) ->
         cmd: "gem install jekyll:3.8.4 bundler:1.17.1"
       jekyll:
         cmd: "jekyll build --trace"
+      deploy:
+        cmd: "gcloud app deploy --quiet"
+      browse:
+        cmd: "glcoud app browse"
 
     watch:
       options:
@@ -105,6 +109,15 @@ module.exports = (grunt) ->
     "build"
     "connect:server"
     "watch"
+  ]
+
+  grunt.registerTask "deploy", "Deploy the webpage on Google App Engine", [
+    "build"
+    "exec:deploy"
+  ]
+
+  grunt.registerTask "browse", "View the hosted webpage in your default browser", [
+    "exec:browse"
   ]
 
   grunt.registerTask "default", [

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - [gem > v2.7.6](https://rubygems.org/)
 - NodeJs and npm
+- [GCloud SDK](https://cloud.google.com/sdk/install) for deployment
 
 ## Installation
 
@@ -19,5 +20,16 @@ npm run gems
 
 Run the development server via `npm start`. Checkout http://localhost:4000.
 
-Or only build the static site via `npm build`. The site will be generated into
+Or only build the static site via `npm run build`. The site will be generated into
 the `./public` directory.
+
+Run `npm run deploy` to upload the static site to Google App Engine.
+
+## Deployment Configuration
+
+The website is hosted with Google Cloud Platform on Google App Engine. For
+first-time deployment follow these steps:
+- Login via `gcloud init`
+- Select a Google Project
+- `npm run deploy`
+- Manage domain mapping via 1blu.de, e.g. *-appspot.com -> joshinkan.de

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,27 @@
+runtime: python27
+api_version: 1
+threadsafe: true
+
+skip_files:
+- node_modules/
+- src/
+- .git/
+- .gitignore
+- _config.yml
+- .sass-cache/
+- package.json
+- package-lock.json
+- Gruntfile.coffee
+
+handlers:
+- url: /
+  static_files: public/verein/index.html
+  upload: public/verein/index.html
+
+- url: /(.*)/
+  static_files: public/\1/index.html
+  upload: public/(.*)/index.html
+
+- url: /(.*)
+  static_files: public/\1
+  upload: public/(.*)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "gems": "grunt gems",
     "build": "grunt build",
-    "start": "grunt serve"
+    "start": "grunt serve",
+    "deploy": "grunt deploy",
+    "browse": "grunt browse"
   },
   "author": "Sven Mischkewitz",
   "license": "MIT",


### PR DESCRIPTION
Use Google SDK and App Engine instead of manual FTP uploads to 1blu.

Resolves #4 